### PR TITLE
installation-linux-<deb|other|rpm.md>: use `systemctl enable --now`

### DIFF
--- a/installation-linux-deb.md
+++ b/installation-linux-deb.md
@@ -44,8 +44,7 @@ installed into `systemd`.
 
 Enable and start the service after install/upgrade:
 ```
-sudo systemctl enable yggdrasil
-sudo systemctl start yggdrasil
+sudo systemctl enable --now yggdrasil
 ```
 
 ## One-off package install from CircleCI

--- a/installation-linux-other.md
+++ b/installation-linux-other.md
@@ -71,8 +71,7 @@ sudo systemctl daemon-reload
 
 Enable and start Yggdrasil:
 ```
-sudo systemctl enable yggdrasil
-sudo systemctl start yggdrasil
+sudo systemctl enable --now yggdrasil
 ```
 
 Once installed as a systemd service, you can read the `yggdrasil` output using

--- a/installation-linux-rpm.md
+++ b/installation-linux-rpm.md
@@ -45,8 +45,7 @@ installed into `systemd`.
 
 Enable and start the service after install/upgrade:
 ```
-sudo systemctl enable yggdrasil
-sudo systemctl start yggdrasil
+sudo systemctl enable --now yggdrasil
 ```
 
 ## One-off package install from CircleCI


### PR DESCRIPTION
If `systemctl enable && systemctl start` can be merged, why to not do that?