### PR TITLE
fix fedora installation error

### DIFF
--- a/installation-linux-rpm.md
+++ b/installation-linux-rpm.md
@@ -25,7 +25,7 @@ echo '[yggdrasil]
 name = Yggdrasil
 baseurl = https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/rpm/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RP^CGPG-KEY-yggdrasil' | sudo tee /etc/yum.repos.d/yggdrasil.repo
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-yggdrasil' | sudo tee /etc/yum.repos.d/yggdrasil.repo
 ```
 
 Create the `yggdrasil` group on your system:

--- a/installation-linux-rpm.md
+++ b/installation-linux-rpm.md
@@ -21,13 +21,11 @@ gpg --armor --no-comment --export-options export-minimal --export 569130E8CA20FB
 
 Add the repository:
 ```
-sudo cat > /etc/yum.repos.d/yggdrasil.repo << EOF
-[yggdrasil]
+echo '[yggdrasil]
 name = Yggdrasil
 baseurl = https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/rpm/
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-yggdrasil
-EOF
+gpgkey=file:///etc/pki/rpm-gpg/RP^CGPG-KEY-yggdrasil' | sudo tee /etc/yum.repos.d/yggdrasil.repo
 ```
 
 Create the `yggdrasil` group on your system:


### PR DESCRIPTION
`sudo tee` will run as root

`sudo cat` doesn't do anything

you would get this error:
```
[rany@HPipi ~]$ sudo cat > /etc/yum.repos.d/yggdrasil.repo << EOF
> [yggdrasil]
> name = Yggdrasil
> baseurl = https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/rpm/
> gpgcheck=1
> gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-yggdrasil
> EOF
bash: /etc/yum.repos.d/yggdrasil.repo: Permission denied
```