### PR TITLE
Fix URL hover boldness, use color change instead

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -159,4 +159,5 @@ div.blogpost div#overview div#excerpt {
 a:hover, a:focus {
     color:#0be;
     font-weight: initial;
+    text-decoration: underline;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -155,3 +155,8 @@ div.blogpost div#overview div#excerpt {
   text-decoration: none;
   font-size: 1em;
 }
+
+a:hover, a:focus {
+    color:#0be;
+    font-weight: initial;
+}


### PR DESCRIPTION
URL boldness on hover is making the rest of text "jump" back and forth in Firefox