### PR TITLE
Uptime is float as time.Seconds returns a float64

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -118,7 +118,7 @@ For each IPv6 address:
 - `bytes_recvd` (`uint64`) contains the number of bytes received from that peer
 - `endpoint` (`string`) contains the connected IPv4/IPv6 address and port of the peering
 - `port` (`uint8`) contains the local switch port number for that peer
-- `uptime` (`uint32`) contains the number of seconds since the peer connection was established
+- `uptime` (`float64`) contains the number of seconds since the peer connection was established
 
 #### `addPeer`
 


### PR DESCRIPTION
See: https://golang.org/src/time/time.go?s=25778:25813#L792

I stumbled upon this when playing with the Admin API, example:
```json
{
  "peers": {
    "<redacted>": {
      ...
      "uptime": 625.732186871
      ...
    },
    "<redacted>": {
      ...
      "uptime": 625.638570027
      ...
    }
  }
}
```