### PR TITLE
configuration: do not configure radvd as a default router

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -362,6 +362,7 @@ On Linux, something like the following should be sufficient to advertise a prefi
 interface eth0
 {
         AdvSendAdvert on;
+        AdvDefaultLifetime 0;
         prefix 300:1111:2222:3333::/64 {
             AdvOnLink on;
             AdvAutonomous on;


### PR DESCRIPTION
The radvd.conf that is documented only announces a route to yggdrasil
space, therefore it should not act as a default router. This line may be
removed if the global unicast space is also routed.