### PR TITLE
Update OpenBSD platform information

### DIFF
--- a/platforms.md
+++ b/platforms.md
@@ -28,12 +28,5 @@ sitemap: true
 
 ## OpenBSD
 
-- Works in TAP mode, but currently doesn't work in TUN mode.
-- You may need to create the TAP adapter first if it doesn't already exist, i.e. `ifconfig tap0 create`.
-- OpenBSD is not capable of listening on both IPv4 and IPv6 at the same time on the same socket, therefore you may need to specify both an IPv4 and an IPv6 listener, like so:
-```
-Listen: [
-    tcp://[::]:12345
-    tcp://0.0.0.0:12345
-]
-```
+- Yggdrasil is well supported on OpenBSD.
+- IfName should only contain the interface name instead of the full path, i.e. `tun0` not `/dev/tun0`


### PR DESCRIPTION
The documentation regarding OpenBSD is outdated / wrong, Such as,

_- Works in TAP mode, but currently doesn't work in TUN mode._
TAP mode does not work on OpenBSD, only TUN mode does, although IfName should only contain the tun interface name, not the full path, i.e. tun0 instead of /dev/tun0

_- You may need to create the TAP adapter first if it doesn't already exist, i.e. `ifconfig tap0 create`._
This is unnecessary, Yggdrasil is capable of creating a tun interface.

_- OpenBSD is not capable of listening on both IPv4 and IPv6 at the same time on the same socket, therefore you may need to specify both an IPv4 and an IPv6 listener, like so:_
OpenBSD is already capable of listening on both IPv4 and IPv6 on the same socket. Doing so would cause a panic:
panic: listen tcp 0.0.0.0:xxxx: bind: address already in use

These observations are tested with Yggdrasil 0.3.15 on OpenBSD 6.8 -stable. 