### PR TITLE
Add internal service Causa Arcana

### DIFF
--- a/services.md
+++ b/services.md
@@ -61,6 +61,9 @@ The following services are available on the Yggdrasil v0.4 network, courtesy of 
 
 - [Nikat's homepage](https://[302:a2a5:dead:ded::a2a5]/)
   - `https://[302:a2a5:dead:ded::a2a5]/`
+
+- [Causa Arcana](http://[200:f0a1:c2ef:37a2:467f:9f74:ae64:9954]/) - Russian blog about information technologies, security and cryptoanarchism
+  - `http://[200:f0a1:c2ef:37a2:467f:9f74:ae64:9954]/`
  
 ----
 


### PR DESCRIPTION
Causa Arcana is my blog (in Russian) about information technologies, security and cryptoanarchism. In clearnet it lives at https://causa-arcana.com. Now it has a mirror in Yggdrasil.

It's a v0.4 service so if you are going to create a separate page for such services then feel free to move it to that page.