### PR TITLE
Link was dead, point to working one

### DIFF
--- a/services.md
+++ b/services.md
@@ -35,8 +35,8 @@ The following services are available on the Yggdrasil v0.4 network, courtesy of 
 - [YaCy](http://[300:7232:2b0e:d6e9:216:3eff:fe38:cefc]:8090/) - internal search engine
   - `http://[300:7232:2b0e:d6e9:216:3eff:fe38:cefc]:8090/`
 
-- [Yggdrasil v0.4 Map](http://[202:d7cd:bd04:6bbc:acc6:b002:da12:86c7]/)
-  - `http://[202:d7cd:bd04:6bbc:acc6:b002:da12:86c7]/`
+- [Yggdrasil v0.4 Map](http://[21e:e795:8e82:a9e2:ff48:952d:55f2:f0bb]/)
+  - `http://[21e:e795:8e82:a9e2:ff48:952d:55f2:f0bb]/`
 
 - [deavmi's homepage](http://[203:75b7:45af:ecca:d641:cd42:38dc:4788]/)
   - `http://[203:75b7:45af:ecca:d641:cd42:38dc:4788]/`


### PR DESCRIPTION
The link to the 0.4 map as listed on the website is dead, according to matrix this is the one that is actually run by a maintainer, so please merge to fix the dead link.