### PR TITLE
Modernize apt installation instructions and improve security

### DIFF
--- a/installation-linux-deb.md
+++ b/installation-linux-deb.md
@@ -22,13 +22,14 @@ sudo apt-get install dirmngr
 Then import the repository key to your `gpg` keyring and export it to your
 `apt` keyring:
 ```
+sudo mkdir -p /usr/local/apt-keys
 gpg --fetch-keys https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/key.txt
-gpg --export 569130E8CA20FBC4CB3FDE555898470A764B32C9 | sudo apt-key add -
+gpg --export 569130E8CA20FBC4CB3FDE555898470A764B32C9 | sudo tee /usr/local/apt-keys/yggdrasil-keyring.gpg > /dev/null
 ```
 
 Add the repository into your `apt` sources:
 ```
-echo 'deb http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' | sudo tee /etc/apt/sources.list.d/yggdrasil.list
+echo 'deb [signed-by=/usr/local/apt-keys/yggdrasil-keyring.gpg] http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' | sudo tee /etc/apt/sources.list.d/yggdrasil.list
 sudo apt-get update
 ```
 


### PR DESCRIPTION
Modern Debian-derived distributions will issue a deprecation warning for
the usage of apt-key add as listed here.  Additionally, by using that
apt-key command, the given key is recognized as valid for all
repositories in /etc/apt/sources.list* -- not just this one.

By using the more modern mechanism, we can avoid that warning and also
import this key in such a way that it is only valid for this repository.

Other projects are also using this method; for instance:

https://apt.syncthing.net/

This post explains the security risks of apt-key:
https://blog.cloudflare.com/dont-use-apt-key/