### PR TITLE
Fix radvd example

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -73,7 +73,6 @@ On Linux, something like the following should be sufficient to advertise a prefi
 interface eth0
 {
         AdvSendAdvert on;
-        AdvDefaultLifetime 0;
         prefix 300:1111:2222:3333::/64 {
             AdvOnLink on;
             AdvAutonomous on;


### PR DESCRIPTION
The Radvd "AdvDefaultLifetime" option should never be set to 0.

I originally made a PR to add this line. With this configuration you get an address and you can can find neighbours in the multicast area, but the route to the outside will get dropped immediately.