### PR TITLE
Add NTP Server

### DIFF
--- a/services.md
+++ b/services.md
@@ -161,6 +161,7 @@ The following services are available on the Yggdrasil v0.4 network, courtesy of 
 
 - `202:a2a5:dead:ded:9a54:4ab5:6aa7:1645` port `123`, hosted by [nikat](https://[302:a2a5:dead:ded::a2a5]/)
 - `223:180a:b95f:6a53:5c70:e704:e9fc:8b8f` port `123`, hosted by mkb2191
+- `200:8ce3:6def:9d4d:a976:9dfb:f0a6:91ce` port `123`, hosted by [Unkn0wnCat](https://kevink.dev), stratum 2, [NTP Pool Monitored](https://www.ntppool.org/scores/45.9.61.155)
 
 ----
 


### PR DESCRIPTION
Hey,

this PR adds my NTP Server, which is in the clearnet under ntp1.1in1.net / 45.9.61.155. Those addresses are also listed in the NTP Pool Project: https://www.ntppool.org/scores/45.9.61.155.

Since I've hooked the server up to the Yggdrasil network anyways I thought I might as well get it listed here 😛 

The server is based in Germany with the upstream-servers being mostly atomic-clock-based NTP-servers hosted at German scientific agencies. This makes this server a stratum 2 time server.