### PR TITLE
Update installation-linux-deb.md

### DIFF
--- a/installation-linux-deb.md
+++ b/installation-linux-deb.md
@@ -35,14 +35,13 @@ sudo apt-get install dirmngr
 Then import the repository key to your `gpg` keyring and export it to your
 `apt` keyring:
 ```
-sudo mkdir -p /usr/local/apt-keys
-gpg --fetch-keys https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/key.txt
-gpg --export BC1BF63BD10B8F1A | sudo tee /usr/local/apt-keys/yggdrasil-keyring.gpg > /dev/null
+sudo mkdir -p /etc/apt/keyrings
+sudo curl https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/key.txt -o /etc/apt/keyrings/yggdrasil.asc
 ```
 
 Add the repository into your `apt` sources:
 ```
-echo 'deb [signed-by=/usr/local/apt-keys/yggdrasil-keyring.gpg] http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' | sudo tee /etc/apt/sources.list.d/yggdrasil.list
+echo 'deb [signed-by=/etc/apt/keyrings/yggdrasil.asc] http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' | sudo tee /etc/apt/sources.list.d/yggdrasil.list
 sudo apt-get update
 ```
 


### PR DESCRIPTION
Remove unnecessary step with gpg, set correct extension to key file, place keyfile to correct place.
`apt` accept gpg key in ascii format, if it placed in /etc/apt/keyrings and filename have `.asc` extension. 