### PR TITLE
Change Yggdrasil Map link to new URL

### DIFF
--- a/services.md
+++ b/services.md
@@ -28,8 +28,8 @@ The following services are available on the Yggdrasil Network, courtesy of our c
 - [Yggdrasil Web directory](http://[21e:a51c:885b:7db0:166e:927:98cd:d186]/)
   - `http://[21e:a51c:885b:7db0:166e:927:98cd:d186]/`
 
-- [Yggdrasil Map](http://[21e:e795:8e82:a9e2:ff48:952d:55f2:f0bb]/)
-  - `http://[21e:e795:8e82:a9e2:ff48:952d:55f2:f0bb]/`
+- [Yggdrasil Map](http://[227:bc24:9a82:e290:7f4a:f992:2ef6:5b34]:8008/)
+  - `http://[227:bc24:9a82:e290:7f4a:f992:2ef6:5b34]:8008/`
 
 - [deavmi's homepage](http://[203:75b7:45af:ecca:d641:cd42:38dc:4788]/)
   - `http://[203:75b7:45af:ecca:d641:cd42:38dc:4788]/`


### PR DESCRIPTION
Updated Yggdrasil Map link to a new address. The original are not updated.